### PR TITLE
Fix issue #2 (as much as possible, anyway)

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ host over the firewall via SOCKS or HTTP proxy without SOCKSifying
 Emacs itself.
 
 There is sample code: 
-http://bitbucket.org/gotoh/connect/src/tip/relay.el ... (*url is not exist*)
+https://github.com/gotoh/ssh-connect/blob/master/relay.el
 
 With this code, you can use `relay-open-network-stream` function instead
 of `open-network-stream` to make network connection. See top comments of

--- a/doc/manual.html
+++ b/doc/manual.html
@@ -599,8 +599,8 @@ You can also relay local socket stream instead of standard I/O.
 </li>
 </ul></div>
 <div class="paragraph"><p>You can download source code
-(<a href="http://bitbucket.org/gotoh/connect/raw/tip/connect.c">connect.c</a>)
-on the <a href="http://bitbucket.org/gotoh/connect/">project page</a>.</p></div>
+(<a href="https://github.com/gotoh/ssh-connect/blob/master/connect.c">connect.c</a>)
+on the <a href="http://github.com/gotoh/connect/">project page</a>.</p></div>
 <div class="paragraph"><p>Pre-compiled binary for MS Windows is also available on
 <a href="http://bitbucket.org/gotoh/connect/downloads/">download page</a>.</p></div>
 </div>
@@ -1138,7 +1138,7 @@ can use this command in Emacs to open network connection with remote
 host over the firewall via SOCKS or HTTP proxy without SOCKSifying
 Emacs itself.</p></div>
 <div class="paragraph"><p>There is sample code:
-<a href="http://bitbucket.org/gotoh/connect/src/tip/relay.el">http://bitbucket.org/gotoh/connect/src/tip/relay.el</a></p></div>
+<a href="https://github.com/gotoh/ssh-connect/blob/master/relay.el">https://github.com/gotoh/ssh-connect/blob/master/relay.el</a></p></div>
 <div class="paragraph"><p>With this code, you can use <tt>relay-open-network-stream</tt> function instead
 of <tt>open-network-stream</tt> to make network connection. See top comments of
 the source for more detail.</p></div>

--- a/doc/manual.txt
+++ b/doc/manual.txt
@@ -17,8 +17,8 @@ Features of `connect.c` are:
 * You can also relay local socket stream instead of standard I/O.
 
 You can download source code 
-(http://bitbucket.org/gotoh/connect/raw/tip/connect.c[connect.c])
-on the http://bitbucket.org/gotoh/connect/[project page].
+(https://github.com/gotoh/ssh-connect/blob/master/relay.el[connect.c])
+on the https://github.com/gotoh/ssh-connect/[project page].
 
 Pre-compiled binary for MS Windows is also available on
 http://bitbucket.org/gotoh/connect/downloads/[download page].
@@ -406,7 +406,7 @@ host over the firewall via SOCKS or HTTP proxy without SOCKSifying
 Emacs itself.
 
 There is sample code: 
-http://bitbucket.org/gotoh/connect/src/tip/relay.el
+https://github.com/gotoh/ssh-connect/blob/master/relay.el
 
 With this code, you can use `relay-open-network-stream` function instead
 of `open-network-stream` to make network connection. See top comments of


### PR DESCRIPTION
Can't fix the download pages/missing binary builds for Windows (for now).